### PR TITLE
Added Gnome Shell 3.18 compatibility to metadata

### DIFF
--- a/workspace-grid@mathematical.coffee.gmail.com/metadata.json
+++ b/workspace-grid@mathematical.coffee.gmail.com/metadata.json
@@ -6,7 +6,7 @@
  "gettext-domain": "workspace-grid",
  "description": "Arranges workspaces in a configurable grid.\nAlso:\n* implements keybindings for left/right workspace navigation (up/down are already implemented)\n* updates workspaces sidebar with grid configuration (use Remove Workspaces Sidebar if you don't want it).\n\nYou may also wish to consider instead of/with this extension: Frippery Bottom Panel (already has workspace grid functionality if you want a bottom panel); Frippery Static Workspaces (holds the number of workspaces static and skips all the workspace grid stuff); Remove Workspaces Sidebar; Workspace Indicator Extension (textual indicator/workspace switcher); WorkspaceBar (graphical indicator/workspace switcher); Workspace navigator extension (use arrow keys to navigate workspaces in the Overview).\nSee homepage for more details.",
  "shell-version": [
-     "3.16"
+     "3.16", "3.18"
  ],
  "url": "https://github.com/zakkak/workspace-grid-gnome-shell-extension",
  "dev-version": "1.3",


### PR DESCRIPTION
Tested and the extension works just as well with the new Gnome Shell 3.18. Added 3.18 to the compatible version list in metadata.json, keeping 3.16. Created the 3.18 branch for this (don't forget to change the default branch in your project).